### PR TITLE
bugfix/Issue-2-Error-On-Install

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "commander": "2.9.0",
     "figlet": "^1.2.0",
     "inquirer": "^1.2.2",
-    "jsforce": "^1.7.1",
+    "jsforce": "1.7.1",
     "lodash": "^4.17.2",
     "lowdb": "^0.14.0",
     "preferences": "^0.2.1",


### PR DESCRIPTION
In response to Issue https://github.com/appiphony/strike-cli/issues/2

There's a breaking change to the jsforce dependency, despite it's usage of semantic versioning. I have updated the package.json to use the specific version that it still compatible.

This issue is reproducible on any environment that does a clean install of strike-cli. This change will need to be published on NPM for any future developers to be able to use this. 

If Appiphony decides to go forward with this change, I am more than happy to walk them through the testing and release process (if needed). 